### PR TITLE
fix Cordova plugin ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ Clipboard
 
 Clipboard management plugin for Cordova/PhoneGap that supports iOS, Android, Windows, and Windows Phone 8.
 
+## Installation
+
+Install the plugin using the CLI:
+
+	cordova plugin add danielsogl-cordova-plugin-clipboard
+
 ## Usage
-
-Install the plugin using the CLI, for instance with PhoneGap:
-
-	phonegap local plugin add danielsogl-cordova-plugin-clipboard
 
 The plugin creates the object `cordova.plugins.clipboard` with the methods `copy(text, onSuccess, onError)` and `paste(onSuccess, onError)`.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "description": "Clipboard management plugin for Cordova/PhoneGap",
   "cordova": {
-    "id": "com.danielsogl.cordova.clipboard",
+    "id": "danielsogl-cordova-plugin-clipboard",
     "platforms": [
       "ios",
       "android",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.danielsogl.cordova.clipboard"
+    id="danielsogl-cordova-plugin-clipboard"
     version="1.0.2">
 
     <engines>
@@ -9,13 +9,9 @@
     </engines>
 
     <name>Clipboard</name>
-
     <description>Clipboard management plugin for Cordova/PhoneGap</description>
-
     <author>Verso Solutions LLC</author>
-
     <keywords>clipboard,copy,paste</keywords>
-
     <license>MIT</license>
 
     <js-module src="www/clipboard.js" name="Clipboard">


### PR DESCRIPTION
Right now the plugin is mixing different package IDs which is causing `cordova prepare` to fail when checking out projects using this plugin. 

Please also accept #2 to fix other Android problems.